### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -27,19 +27,19 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Digital Ocean Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
           username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
           password: ${{ secrets.DO_ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           push: true
           tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: realiotech/gitops

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -27,19 +27,19 @@ jobs:
     environment: stage
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Digital Ocean Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
           username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
           password: ${{ secrets.DO_ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           push: true
           tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: realiotech/gitops


### PR DESCRIPTION
## Summary
- Pins GitHub Actions in workflow files to immutable commit SHAs (security best practice — prevents tag-rewrite supply-chain attacks).
- Adds `.github/dependabot.yml` so Dependabot keeps the pinned SHAs up to date going forward.

## Test plan
- [ ] Workflow runs trigger and pass on this branch.
- [ ] Dependabot detects the new config and opens its first update PR within 24h.