### PR TITLE
chore: gate yarn installs by 3-day minimum release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -10,6 +10,15 @@ on:
       - '!docker/testnet*'
       - '!subgraph.testnet.yaml'
       - '!subgraph.yaml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!docker/testnet*'
+      - '!subgraph.testnet.yaml'
+      - '!subgraph.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    runs-on: [ubuntu-latest]
     environment: prod
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     environment: prod
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
       uses: actions/checkout@v4

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -13,26 +13,62 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-only:
-    if: github.event_name == 'pull_request'
-    uses: realiotech/workflows/.github/workflows/docker.yaml@main
-    with:
-      DEPLOY: false
-      ENVIRONMENT: prod
-      PUSH: false
-      RUN_NUMBER: ${{ github.run_number }}
-      SHA: ${{ github.sha }}
-  build-and-deploy:
+  build:
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    environment: prod
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Digital Ocean Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
+          username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
+          password: ${{ secrets.DO_ACCESS_TOKEN }}
+      - name: GitHub Actions Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ github.workflow }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ github.workflow }}-buildx-${{ github.sha }}
+            ${{ github.workflow }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: docker/mainnet.Dockerfile
+  update-gitops:
     if: github.event_name != 'pull_request'
-    uses: realiotech/workflows/.github/workflows/docker.yaml@main
-    with:
-      DEPLOY: true
-      ENVIRONMENT: prod
-      IMAGE_NAME: dstrx-subgraph
-      MANIFEST_PATH: explorer-graph-node/base/dstrx-subgraph-job.yaml
-      PUSH: true
-      RUN_NUMBER: ${{ github.run_number }}
-      SHA: ${{ github.sha }}
-    secrets:
-      GITOPS_PAT: ${{ secrets.GITOPS_PAT }}
-      REGISTRY_PASSWORD: ${{ secrets.DO_REGISTRY_PASSWORD_PROD }}
+    needs: build
+    environment: prod
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    steps:
+    - name: Checkout gitops repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITOPS_PAT }}
+        repository: realiotech/gitops
+        ref: main
+    - name: Update Kubernetes manifest
+      run: |
+        if cat explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}; then
+          echo "Image tag already exists in the manifest"
+          exit 0
+        fi
+        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}"'|' explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml
+        git config user.name 'github-actions-bot'
+        git config user.email 'devops@realio.fund'
+        git add .
+        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}'
+        git pull --rebase
+        git push
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITOPS_PAT }}

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -13,62 +13,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
-    environment: prod
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Login to Digital Ocean Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
-          username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
-          password: ${{ secrets.DO_ACCESS_TOKEN }}
-      - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ github.workflow }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ github.workflow }}-buildx-${{ github.sha }}
-            ${{ github.workflow }}
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          file: docker/mainnet.Dockerfile
-  update-gitops:
+  build-only:
+    if: github.event_name == 'pull_request'
+    uses: realiotech/workflows/.github/workflows/docker.yaml@main
+    with:
+      DEPLOY: false
+      ENVIRONMENT: prod
+      PUSH: false
+      RUN_NUMBER: ${{ github.run_number }}
+      SHA: ${{ github.sha }}
+  build-and-deploy:
     if: github.event_name != 'pull_request'
-    needs: build
-    environment: prod
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
-    steps:
-    - name: Checkout gitops repository
-      uses: actions/checkout@v4
-      with:
-        token: ${{ secrets.GITOPS_PAT }}
-        repository: realiotech/gitops
-        ref: main
-    - name: Update Kubernetes manifest
-      run: |
-        if cat explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}; then
-          echo "Image tag already exists in the manifest"
-          exit 0
-        fi
-        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}"'|' explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml
-        git config user.name 'github-actions-bot'
-        git config user.email 'devops@realio.fund'
-        git add .
-        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}'
-        git pull --rebase
-        git push
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITOPS_PAT }}
+    uses: realiotech/workflows/.github/workflows/docker.yaml@main
+    with:
+      DEPLOY: true
+      ENVIRONMENT: prod
+      IMAGE_NAME: dstrx-subgraph
+      MANIFEST_PATH: explorer-graph-node/base/dstrx-subgraph-job.yaml
+      PUSH: true
+      RUN_NUMBER: ${{ github.run_number }}
+      SHA: ${{ github.sha }}
+    secrets:
+      GITOPS_PAT: ${{ secrets.GITOPS_PAT }}
+      REGISTRY_PASSWORD: ${{ secrets.DO_REGISTRY_PASSWORD_PROD }}

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-latest]
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
     environment: prod
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: docker/mainnet.Dockerfile
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     environment: prod
-    runs-on: [ubuntu-latest]
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
     steps:
     - name: Checkout gitops repository
       uses: actions/checkout@v4
@@ -59,15 +59,16 @@ jobs:
         ref: main
     - name: Update Kubernetes manifest
       run: |
-        if cat explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}; then
+        if cat explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}; then
           echo "Image tag already exists in the manifest"
           exit 0
         fi
-        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}"'|' explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml
+        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}"'|' explorer-graph-node/overlays/prod/dstrx-subgraph-job.yaml
         git config user.name 'github-actions-bot'
         git config user.email 'devops@realio.fund'
         git add .
-        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}'
+        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}'
+        git pull --rebase
         git push
     env:
       GITHUB_TOKEN: ${{ secrets.GITOPS_PAT }}

--- a/.github/workflows/mainnet.yaml
+++ b/.github/workflows/mainnet.yaml
@@ -27,19 +27,19 @@ jobs:
     environment: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Digital Ocean Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
           username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
           password: ${{ secrets.DO_ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           push: true
           tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-prod/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: realiotech/gitops

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -10,6 +10,15 @@ on:
       - '!docker/mainnet*'
       - '!subgraph.mainnet.yaml'
       - '!subgraph.yaml'
+  pull_request:
+    branches:
+      - stage
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!docker/mainnet*'
+      - '!subgraph.mainnet.yaml'
+      - '!subgraph.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-latest]
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
     environment: stage
     steps:
       - name: Checkout
@@ -41,7 +41,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}
+          tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: docker/testnet.Dockerfile
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     environment: stage
-    runs-on: [ubuntu-latest]
+    runs-on: [blacksmith-2vcpu-ubuntu-2404]
     steps:
     - name: Checkout gitops repository
       uses: actions/checkout@v4
@@ -59,15 +59,16 @@ jobs:
         ref: main
     - name: Update Kubernetes manifest
       run: |
-        if cat explorer-graph-node/base/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}; then
+        if cat explorer-graph-node/base/dstrx-subgraph-job.yaml | grep ${{ github.sha }}-${{ github.run_number }}; then
           echo "Image tag already exists in the manifest"
           exit 0
         fi
-        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}"'|' explorer-graph-node/base/dstrx-subgraph-job.yaml
+        sed -i 's|image: .*$|image: '"registry.digitalocean.com/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}"'|' explorer-graph-node/base/dstrx-subgraph-job.yaml
         git config user.name 'github-actions-bot'
         git config user.email 'devops@realio.fund'
         git add .
-        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}-${{ github.run_attempt }}'
+        git commit -m 'Update image tag to ${{ github.sha }}-${{ github.run_number }}'
+        git pull --rebase
         git push
     env:
       GITHUB_TOKEN: ${{ secrets.GITOPS_PAT }}

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    runs-on: [ubuntu-latest]
     environment: stage
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     environment: stage
-    runs-on: [blacksmith-2vcpu-ubuntu-2404]
+    runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
       uses: actions/checkout@v4

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -27,19 +27,19 @@ jobs:
     environment: stage
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Digital Ocean Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ vars.DO_IMAGE_REGISTRY_URL }}
           username: ${{ vars.DO_IMAGE_REGISTRY_USER }}
           password: ${{ secrets.DO_ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
@@ -47,7 +47,7 @@ jobs:
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           push: true
           tags: ${{ vars.DO_IMAGE_REGISTRY_URL }}/kubernetes-stage/dstrx-subgraph:${{ github.sha }}-${{ github.run_number }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: realiotech/gitops

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,3 @@
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 4320

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
 nodeLinker: node-modules
 
 npmMinimalAgeGate: 4320
+
+npmRegistryServer: "https://registry.npmjs.org"

--- a/docker/mainnet.Dockerfile
+++ b/docker/mainnet.Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Copy the rest of the application code
 COPY . .

--- a/docker/testnet.Dockerfile
+++ b/docker/testnet.Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Copy the rest of the application code
 COPY . .

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@graphprotocol/graph-cli": "^0.97.0",
     "@graphprotocol/graph-ts": "0.32.0"
   },
-  "packageManager": "yarn@4.8.1+sha512.bc946f2a022d7a1a38adfc15b36a66a3807a67629789496c3714dd1703d2e6c6b1c69ff9ec3b43141ac7a1dd853b7685638eb0074300386a59c18df351ef8ff6",
+  "packageManager": "yarn@4.15.0+sha512.faf6b99be7e1e8a88a46b785b2842b0e17f2ba93f16b39764ddadd48407a0a2602d2f4bd7d6a7e58d308215d29d6f9cfeb7919709b020e57324f60a353e18f94",
   "dependencies": {
     "@amxx/graphprotocol-utils": "^1.2.0"
   }


### PR DESCRIPTION
## Summary
- Adds `npmMinimalAgeGate: 4320` (3 days, in minutes) to `.yarnrc.yml` as a supply-chain defense — yarn will refuse to install package versions younger than 3 days, giving the community time to spot and yank malicious releases
- Bumps yarn from 4.8.1 → 4.15.0 because `npmMinimalAgeGate` was added in Yarn Berry 4.10

## Test plan
- [ ] `corepack prepare yarn@4.15.0 --activate`
- [ ] `yarn install --immutable` — confirm lockfile still resolves cleanly under 4.15
- [ ] CI on this branch (graph-cli codegen/build) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)